### PR TITLE
Try handle cases where empty encoding detect happens

### DIFF
--- a/src/DaveChild/TextStatistics/Text.php
+++ b/src/DaveChild/TextStatistics/Text.php
@@ -31,7 +31,8 @@ class Text
             return self::$clean[$key];
         }
 
-        $strText = mb_convert_encoding($strText, 'UTF-8', 'ISO-8859-1');
+        $encoding = mb_detect_encoding($strText);
+        $strText  = mb_convert_encoding($strText, 'UTF-8', !empty($encoding) ? $encoding : null);
 
         // Curly quotes etc
         $strText = str_replace(


### PR DESCRIPTION
Some users on php 8.2 are getting value errors from `false` or empty arrays returned from detection so this trys to handle that gracefully